### PR TITLE
Disparition des bombes

### DIFF
--- a/jeu.js
+++ b/jeu.js
@@ -196,7 +196,7 @@ function hitPlatforms(bomb, platforms) {
 
 	if(speedBomb >= 150)
 	{
-		bomb.destroy(true);
+		bomb.destroy(true); 
 		speedBomb = 0;
 	}
 }


### PR DESCRIPTION
Si la valeur du compteur 'speedBomb' atteint une valeur max, la bombe est détruite.